### PR TITLE
Fix error: add value definition and initialisation

### DIFF
--- a/src/Octoliner.cpp
+++ b/src/Octoliner.cpp
@@ -5,6 +5,7 @@ void Octoliner::begin(uint8_t value) {
     Wire.begin();
     pwmFreq(30000);
     analogWrite(0, value);
+    value = 0;
 }
 
 void Octoliner::writeCmdPin(IOcommand command, uint8_t pin, bool sendStop) {

--- a/src/Octoliner.h
+++ b/src/Octoliner.h
@@ -78,6 +78,7 @@ private:
     void writeCmd(IOcommand command, bool sendStop = true);
     int read16Bit();
     uint32_t read32bit();
+    float value;
 };
 
 #endif //__GPIOEXPANDER_H__


### PR DESCRIPTION
Add "value" as class member (need for mapLine)